### PR TITLE
Adds hover state to event-indicator

### DIFF
--- a/styles/components/_calendar.scss
+++ b/styles/components/_calendar.scss
@@ -55,6 +55,10 @@
 
   &:hover {
     color: #fff;
+    
+    .cal-event-indicator {
+      background-color: $orange;
+    }
   }
 }
 


### PR DESCRIPTION
Sets different background-color on event indicator when cal-event is hovered. This so to better see the sequential order of the event. Maybe not the best color, or selector position. :neckbeard:
