### PR TITLE
Adds button to re-hide previous events and new event day algorithm

### DIFF
--- a/components/calendar/index.js
+++ b/components/calendar/index.js
@@ -9,7 +9,7 @@ require('isomorphic-fetch');
 
 const TODAY = moment();
 
-function getActiveEvent(postDays, active) {
+function getActiveEvent (postDays, active) {
   if (active < 0 && postDays.length > 0) {
     return postDays[0].index;
   }
@@ -53,7 +53,7 @@ const Calendar = React.createClass({
   },
 
   preDaysClickHandler: function () {
-    this.setState(Object.assign({}, this.state, { preDaysSectionActive: true }));
+    this.setState(Object.assign({}, this.state, { preDaysSectionActive: !this.state.preDaysSectionActive }));
   },
 
   buildEvents: function (events) {
@@ -64,6 +64,7 @@ const Calendar = React.createClass({
     let preDays = [];
     let postDays = [];
     let preDaysSection = '';
+    let toggleCalendarSection = '';
 
     events.forEach(function (event, index) {
       event.index = index;
@@ -110,9 +111,14 @@ const Calendar = React.createClass({
           { preDays }
         </div>
       );
+      toggleCalendarSection = (
+        <button className="cal-button--preDays" onClick={this.preDaysClickHandler}>
+          Skjul tidligere arrangementer
+        </button>
+      );
     }
     else if (preDays.length > 0 && !this.state.preDaysSectionActive) {
-      preDaysSection = (
+      toggleCalendarSection = (
         <button className="cal-button--preDays" onClick={this.preDaysClickHandler}>Vis tidligere arrangementer</button>
       );
     }
@@ -122,6 +128,7 @@ const Calendar = React.createClass({
 
     return {
       postDaysSection: postDays,
+      toggleCalendarSection: toggleCalendarSection,
       preDaysSection: preDaysSection
     };
   },
@@ -139,13 +146,14 @@ const Calendar = React.createClass({
       );
     }
     else {
-      let { postDaysSection, preDaysSection } = this.buildEvents(this.state.events);
+      let { postDaysSection, toggleCalendarSection, preDaysSection } = this.buildEvents(this.state.events);
 
       calendarContent = (
         <div>
-          <div className="cal-timeline" />
+          <div className="cal-timeline"/>
 
           { preDaysSection }
+          { toggleCalendarSection }
           { postDaysSection }
         </div>
       );

--- a/components/calendar/index.js
+++ b/components/calendar/index.js
@@ -7,13 +7,13 @@ import { API_EVENTS_URL } from '../../common/constants';
 require('es6-promise').polyfill();
 require('isomorphic-fetch');
 
-const TODAY = moment();
+const NOW = moment();
 
-function getActiveEvent (postDays, postEs, active) {
+function getActiveEvent (postDays, futureEvents, active) {
   if (active < 0 && postDays.length > 0) {
     return postDays[0].props.events[0].index;
-  } else if (active < 0 && postEs[0]) {
-    return postEs[0].index;
+  } else if (active < 0 && futureEvents[0]) {
+    return futureEvents[0].index;
   }
 
   return active;
@@ -58,14 +58,14 @@ const Calendar = React.createClass({
     this.setState(Object.assign({}, this.state, { preDaysSectionActive: !this.state.preDaysSectionActive }));
   },
 
-  partitionEvents: function (preEs, postEs, active) {
+  partitionEvents: function (pastEvents, futureEvents, active) {
     let preDay, postDay;
 
-    if (preEs.length) {
-      preDay = <Day events={preEs} active={active} eventClickHandler={this.eventClickHandler}/>;
+    if (pastEvents.length) {
+      preDay = <Day events={pastEvents} active={active} eventClickHandler={this.eventClickHandler}/>;
     }
-    if (postEs.length) {
-      postDay = <Day events={postEs} active={active} eventClickHandler={this.eventClickHandler}/>;
+    if (futureEvents.length) {
+      postDay = <Day events={futureEvents} active={active} eventClickHandler={this.eventClickHandler}/>;
     }
 
     return {
@@ -78,8 +78,8 @@ const Calendar = React.createClass({
     let id = 0;
     let previousEventDate;
 
-    let preEs = [];
-    let postEs = [];
+    let pastEvents = [];
+    let futureEvents = [];
 
     let preDays = [];
     let postDays = [];
@@ -91,8 +91,8 @@ const Calendar = React.createClass({
       const currentEventDate = moment(event.end_time);
 
       if (currentEventDate.isAfter(previousEventDate, 'day')) {
-        const active = getActiveEvent(postDays, postEs, this.state.active);
-        const { preDay, postDay } = this.partitionEvents(preEs, postEs, active);
+        const active = getActiveEvent(postDays, futureEvents, this.state.active);
+        const { preDay, postDay } = this.partitionEvents(pastEvents, futureEvents, active);
 
         if (preDay) {
           preDays.push(preDay);
@@ -101,22 +101,22 @@ const Calendar = React.createClass({
           postDays.push(postDay);
         }
 
-        preEs = [];
-        postEs = [];
+        pastEvents = [];
+        futureEvents = [];
       }
-      if (currentEventDate.isBefore(TODAY)) {
-        preEs.push(event);
+      if (currentEventDate.isAfter(NOW)) {
+        futureEvents.push(event);
       }
       else {
-        postEs.push(event);
+        pastEvents.push(event);
       }
 
       previousEventDate = currentEventDate;
       id++;
     }, this);
 
-    const active = getActiveEvent(postDays, postEs, this.state.active);
-    const { preDay, postDay } = this.partitionEvents(preEs, postEs, active);
+    const active = getActiveEvent(postDays, futureEvents, this.state.active);
+    const { preDay, postDay } = this.partitionEvents(pastEvents, futureEvents, active);
     if (preDay) {
       preDays.push(preDay);
     }

--- a/components/calendar/index.js
+++ b/components/calendar/index.js
@@ -56,9 +56,24 @@ const Calendar = React.createClass({
     this.setState(Object.assign({}, this.state, { preDaysSectionActive: !this.state.preDaysSectionActive }));
   },
 
+  partitionEvents: function (preEs, postEs) {
+    let preDay, postDay;
+
+    if (preEs.length) {
+      preDay = <Day events={preEs} active={this.state.active} eventClickHandler={this.eventClickHandler}/>;
+    }
+    if (postEs.length) {
+      postDay = <Day events={postEs} active={this.state.active} eventClickHandler={this.eventClickHandler}/>;
+    }
+
+    return {
+      preDay: preDay,
+      postDay: postDay
+    };
+  },
+
   buildEvents: function (events) {
     let id = 0;
-    let daysEvents = [];
     let previousEventDate;
 
     let preEs = [];
@@ -75,16 +90,9 @@ const Calendar = React.createClass({
       const currentEventDate = moment(event.end_time);
 
       if (currentEventDate.isAfter(previousEventDate, 'day')) {
-        if (preEs.length) {
-          preDays.push(
-            <Day events={preEs} active={this.state.active} eventClickHandler={this.eventClickHandler} key={id}/>
-          );
-        }
-        if (postEs.length) {
-          postDays.push(
-            <Day events={postEs} active={this.state.active} eventClickHandler={this.eventClickHandler} key={id}/>
-          );
-        }
+        const { preDay, postDay } = this.partitionEvents(preEs, postEs);
+        preDays.push(preDay);
+        postDays.push(postDay);
 
         preEs = [];
         postEs = [];
@@ -101,19 +109,9 @@ const Calendar = React.createClass({
       id++;
     }, this);
 
-    if (daysEvents.length > 0) {
-      const active = getActiveEvent(postDays, this.state.active);
-      if (previousEventDate.isBefore(TODAY, 'day')) {
-        preDays.push(
-          <Day events={daysEvents} active={active} eventClickHandler={this.eventClickHandler} key={id}/>
-        );
-      }
-      else {
-        postDays.push(
-          <Day events={daysEvents} active={active} eventClickHandler={this.eventClickHandler} key={id}/>
-        );
-      }
-    }
+    const { preDay, postDay } = this.partitionEvents(preEs, postEs);
+    preDays.push(preDay);
+    postDays.push(postDay);
 
     if (preDays.length > 0 && this.state.preDaysSectionActive) {
       preDaysSection = (

--- a/components/calendar/index.js
+++ b/components/calendar/index.js
@@ -68,18 +68,31 @@ const Calendar = React.createClass({
 
     events.forEach(function (event, index) {
       event.index = index;
-      const currentEventDate = moment(event.start_time);
+      const currentEventDate = moment(event.end_time);
 
       if (currentEventDate.isAfter(previousEventDate, 'day')) {
-        if (previousEventDate.isBefore(TODAY, 'day')) {
+
+        let preEs = [];
+        let postEs = [];
+
+        daysEvents.forEach(function (e) {
+          if (moment(e.end_time).isBefore(TODAY)) {
+            preEs.push(e);
+          }
+          else {
+            postEs.push(e);
+          }
+
+        }, this);
+
+        if (preEs.length) {
           preDays.push(
-            <Day events={daysEvents} active={this.state.active} eventClickHandler={this.eventClickHandler} key={id}/>
+            <Day events={preEs} active={this.state.active} eventClickHandler={this.eventClickHandler} key={id}/>
           );
         }
-        else {
-          const active = getActiveEvent(postDays, this.state.active);
+        if (postEs.length) {
           postDays.push(
-            <Day events={daysEvents} active={active} eventClickHandler={this.eventClickHandler} key={id}/>
+            <Day events={postEs} active={this.state.active} eventClickHandler={this.eventClickHandler} key={id}/>
           );
         }
 

--- a/components/calendar/index.js
+++ b/components/calendar/index.js
@@ -68,10 +68,7 @@ const Calendar = React.createClass({
       postDay = <Day events={futureEvents} active={active} eventClickHandler={this.eventClickHandler}/>;
     }
 
-    return {
-      preDay: preDay,
-      postDay: postDay
-    };
+    return { preDay, postDay };
   },
 
   buildEvents: function (events) {
@@ -84,7 +81,6 @@ const Calendar = React.createClass({
     let preDays = [];
     let postDays = [];
     let preDaysSection = '';
-    let toggleCalendarSection = '';
 
     events.forEach(function (event, index) {
       event.index = index;
@@ -124,22 +120,21 @@ const Calendar = React.createClass({
       postDays.push(postDay);
     }
 
+    let toggleCalendarSection = (
+      <button className="cal-button--preDays" onClick={this.preDaysClickHandler}>
+        {( this.state.preDaysSectionActive ? 'Skjul' : 'Vis' ) + ' tidligere arrangementer' }
+      </button>
+    );
+
     if (preDays.length > 0 && this.state.preDaysSectionActive) {
       preDaysSection = (
         <div className="cal-section--preDays">
           { preDays }
         </div>
       );
-      toggleCalendarSection = (
-        <button className="cal-button--preDays" onClick={this.preDaysClickHandler}>
-          Skjul tidligere arrangementer
-        </button>
-      );
     }
-    else if (preDays.length > 0 && !this.state.preDaysSectionActive) {
-      toggleCalendarSection = (
-        <button className="cal-button--preDays" onClick={this.preDaysClickHandler}>Vis tidligere arrangementer</button>
-      );
+    else if (preDays.length <= 0) {
+      toggleCalendarSection = '';
     }
     else {
       preDaysSection = '';
@@ -147,8 +142,8 @@ const Calendar = React.createClass({
 
     return {
       postDaysSection: postDays,
-      toggleCalendarSection: toggleCalendarSection,
-      preDaysSection: preDaysSection
+      toggleCalendarSection,
+      preDaysSection
     };
   },
 

--- a/components/calendar/index.js
+++ b/components/calendar/index.js
@@ -61,6 +61,9 @@ const Calendar = React.createClass({
     let daysEvents = [];
     let previousEventDate;
 
+    let preEs = [];
+    let postEs = [];
+
     let preDays = [];
     let postDays = [];
     let preDaysSection = '';
@@ -68,23 +71,10 @@ const Calendar = React.createClass({
 
     events.forEach(function (event, index) {
       event.index = index;
+
       const currentEventDate = moment(event.end_time);
 
       if (currentEventDate.isAfter(previousEventDate, 'day')) {
-
-        let preEs = [];
-        let postEs = [];
-
-        daysEvents.forEach(function (e) {
-          if (moment(e.end_time).isBefore(TODAY)) {
-            preEs.push(e);
-          }
-          else {
-            postEs.push(e);
-          }
-
-        }, this);
-
         if (preEs.length) {
           preDays.push(
             <Day events={preEs} active={this.state.active} eventClickHandler={this.eventClickHandler} key={id}/>
@@ -96,11 +86,18 @@ const Calendar = React.createClass({
           );
         }
 
-        daysEvents = [];
+        preEs = [];
+        postEs = [];
+      }
+
+      if (currentEventDate.isBefore(TODAY)) {
+        preEs.push(event);
+      }
+      else {
+        postEs.push(event);
       }
 
       previousEventDate = currentEventDate;
-      daysEvents.push(event);
       id++;
     }, this);
 

--- a/styles/components/_calendar.scss
+++ b/styles/components/_calendar.scss
@@ -48,6 +48,10 @@
     color: $orange;
   }
 
+  &:focus {
+    outline: none;
+  }
+
   &:not(:last-child) {
     margin-bottom: 25px;
   }


### PR DESCRIPTION
Adds a button to re-hide previous events that sits between preDays and postDays, if there are any preDays to speak of. It's the same button used for hiding, but now it toggles instead. This resolves #20

New to this PR is a change to how events are organized into days. Previously all events of a day would remain as a "future event" despite perhaps both the start and end date of the events having passed. With this PR, the partitioning is a bit more clever. We now instead look at end dates and split accordingly. If you're in the middle of a day with two events, and the first event has ended, then that event will now be in "past events". In other words, this closes #16 

Also I fixed a bug with the active event feature that I probably caused earlier without anyone noticing. :speak_no_evil: 

For what it's worth, I _tried_ to split the code up more by moving partitionEvents out of the main logic block, but splitting things up much more than this would mean passing parameters to functions that seemed somewhat unreasonable.