### PR TITLE
Support events with end_time after midnight

### DIFF
--- a/components/calendar/__tests__/__snapshots__/calendar.js.snap
+++ b/components/calendar/__tests__/__snapshots__/calendar.js.snap
@@ -76,7 +76,7 @@ Array [
                 },
                 Object {
                   "content": "Etter konkurranserunden, er det etterfest på Cafè 3b.",
-                  "end_time": "2017-08-21T21:59:00Z",
+                  "end_time": "2017-08-22T01:59:00Z",
                   "id": 75,
                   "index": 3,
                   "start_time": "2017-08-21T21:00:00Z",
@@ -173,7 +173,7 @@ Array [
                 },
                 Object {
                   "content": "Etter konkurranserunden, er det etterfest på Cafè 3b.",
-                  "end_time": "2017-08-21T21:59:00Z",
+                  "end_time": "2017-08-22T01:59:00Z",
                   "id": 75,
                   "index": 3,
                   "start_time": "2017-08-21T21:00:00Z",
@@ -313,7 +313,7 @@ Array [
                 },
                 Object {
                   "content": "Etter konkurranserunden, er det etterfest på Cafè 3b.",
-                  "end_time": "2017-08-21T21:59:00Z",
+                  "end_time": "2017-08-22T01:59:00Z",
                   "id": 75,
                   "index": 3,
                   "start_time": "2017-08-21T21:00:00Z",

--- a/components/calendar/__tests__/calendar.js
+++ b/components/calendar/__tests__/calendar.js
@@ -6,7 +6,7 @@ import { shallow, mount } from 'enzyme';
 import moment from 'moment';
 
 const beforeDate = new Date('2017-08-01T00:00:00Z').valueOf();
-const duringDate = new Date('2017-08-20T00:00:00Z').valueOf();
+const duringDate = new Date('2017-08-20T14:00:00Z').valueOf();
 const afterDate = new Date('2017-09-01T00:00:00Z').valueOf();
 
 it('renders correctly before fadderuker', () => {

--- a/components/calendar/__tests__/calendarData.json
+++ b/components/calendar/__tests__/calendarData.json
@@ -25,7 +25,7 @@
       "title": "Etterfest",
       "content": "Etter konkurranserunden, er det etterfest på Cafè 3b.",
       "start_time": "2017-08-21T21:00:00Z",
-      "end_time": "2017-08-21T21:59:00Z"
+      "end_time": "2017-08-22T01:59:00Z"
   },
   {
       "id": 72,

--- a/components/calendar/calendar.js
+++ b/components/calendar/calendar.js
@@ -63,9 +63,10 @@ class Calendar extends Component {
 
     events.forEach((event, index) => {
       event.index = index;
-      const currentEventDate = moment(event.end_time);
+      const currentEventStartDate = moment(event.start_time);
+      const currentEventEndDate = moment(event.end_time);
 
-      if (currentEventDate.isAfter(previousEventDate, 'day')) {
+      if (currentEventStartDate.isAfter(previousEventDate, 'day')) {
         const active = getActiveEvent(postDays, futureEvents, this.state.active);
         const { preDay, postDay } = this.partitionEvents(pastEvents, futureEvents, active);
 
@@ -79,14 +80,14 @@ class Calendar extends Component {
         pastEvents = [];
         futureEvents = [];
       }
-      if (currentEventDate.isAfter(NOW)) {
+      if (currentEventEndDate.isAfter(NOW)) {
         futureEvents.push(event);
       }
       else {
         pastEvents.push(event);
       }
 
-      previousEventDate = currentEventDate;
+      previousEventDate = currentEventStartDate;
     });
 
     const active = getActiveEvent(postDays, futureEvents, this.state.active);


### PR DESCRIPTION
The current design will not make sense if the event lasts more than 24 hours, but I doubt that's something we have to support.

![image](https://user-images.githubusercontent.com/1637715/28388817-341986a2-6cd4-11e7-9aaf-90bbe51d10f4.png)
