### PR TITLE
Temp fix leaderboard crash when missing sheet

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -18,20 +18,20 @@ import Leaderboard from '../components/leaderboard';
 
 export const getServerSideProps = async () => {
   const events = await getEvents();
-  const leaderboard = await getLeaderboard();
+  // const leaderboard = await getLeaderboard();
   const applicationPeriod = await getAvailableApplicationPeriod();
 
   return {
     props: {
       events,
       applicationPeriod,
-      leaderboard,
+      // leaderboard,
     },
   };
 };
 
-const App = ({ events, applicationPeriod, leaderboard }) => {
-  const { active, groupNames, data } = leaderboard;
+const App = ({ events, applicationPeriod }) => {
+  // const { active, groupNames, data } = leaderboard;
 
   return (
     <>
@@ -43,7 +43,7 @@ const App = ({ events, applicationPeriod, leaderboard }) => {
         <About />
         <Fadder />
         <Calendar events={events} />
-        {active && <Leaderboard data={data} groupNames={groupNames} />}
+        {/* {active && <Leaderboard data={data} groupNames={groupNames} />} */}
         <Join applicationDeadline={applicationPeriod.deadline} />
         <Slack />
         <Warning />


### PR DESCRIPTION
Temporarily comments out all leaderboard stuff because of missing sheet. This needs to be uncommented in the case that we actually intend to use this feature.