### PR TITLE
Add spacing between calendar days and entries and fix leaderboard missing

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -18,21 +18,19 @@ import Leaderboard from '../components/leaderboard';
 
 export const getServerSideProps = async () => {
   const events = await getEvents();
-  // const leaderboard = await getLeaderboard();
+  const leaderboard = await getLeaderboard();
   const applicationPeriod = await getAvailableApplicationPeriod();
 
   return {
     props: {
       events,
       applicationPeriod,
-      // leaderboard,
+      leaderboard,
     },
   };
 };
 
-const App = ({ events, applicationPeriod }) => {
-  // const { active, groupNames, data } = leaderboard;
-
+const App = ({ events, applicationPeriod, leaderboard }) => {
   return (
     <>
       <Head>
@@ -43,7 +41,9 @@ const App = ({ events, applicationPeriod }) => {
         <About />
         <Fadder />
         <Calendar events={events} />
-        {/* {active && <Leaderboard data={data} groupNames={groupNames} />} */}
+        {leaderboard && leaderboard.active && (
+          <Leaderboard data={leaderboard.data} groupNames={leaderboard.groupNames} />
+        )}
         <Join applicationDeadline={applicationPeriod.deadline} />
         <Slack />
         <Warning />

--- a/styles/components/_calendar.scss
+++ b/styles/components/_calendar.scss
@@ -9,6 +9,7 @@
 
 .cal-day {
   position: relative;
+  padding-top: 45px;
 }
 
 .cal-day--string {

--- a/styles/components/_calendar.scss
+++ b/styles/components/_calendar.scss
@@ -9,7 +9,7 @@
 
 .cal-day {
   position: relative;
-  padding-top: 45px;
+  padding-top: 60px;
 }
 
 .cal-day--string {
@@ -137,7 +137,7 @@
   }
 
   .cal-day {
-    padding-top: 75px;
+    padding-top: 60px;
   }
 
   .cal-day--string {


### PR DESCRIPTION
- On desktop, the calendar now has some spacing between the day text and the actual entries (mobile already has this)
- When the leaderboard could not be fetched, it should now correctly not try to render it.

Before:
<img width="821" alt="image" src="https://github.com/dotkom/glowing-fortnight/assets/40792825/30f81f0a-f105-43d5-bd4b-57b83d28ee03">

After:
<img width="821" alt="image" src="https://github.com/dotkom/glowing-fortnight/assets/40792825/276fc022-f6bf-4538-bccf-3a1e9ffbcb99">
